### PR TITLE
[Feature] Exception Handling 및 ErrorResponse / ResultResponse 설정 

### DIFF
--- a/src/main/java/com/sopt/wokat/global/entity/BaseEntity.java
+++ b/src/main/java/com/sopt/wokat/global/entity/BaseEntity.java
@@ -1,0 +1,35 @@
+package com.sopt.wokat.global.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.*;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Schema(description = "기본 컬럼")
+@Getter @Setter 
+public class BaseEntity {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    @Schema(description = "유저 고유 ID")
+    private Long id;
+
+    @CreatedDate
+    @Column(name = "created_at")
+    @Schema(description = "생성 일자")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    @Schema(description = "업데이트 일자")
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/sopt/wokat/global/error/ErrorCode.java
+++ b/src/main/java/com/sopt/wokat/global/error/ErrorCode.java
@@ -1,0 +1,38 @@
+package com.sopt.wokat.global.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * ErrorCode Convention
+ * - 도메인 별로 나누어 관리
+ * - [주체_이유] 형태로 생성
+ * - 코드는 도메인명 앞에서부터 1~2글자로 사용
+ * - 메시지는 "~~다."로 마무리
+ */
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    
+    //! Global
+	INTERNAL_SERVER_ERROR(500, "G001", "내부 서버 오류입니다."),
+	METHOD_NOT_ALLOWED(405, "G002", "허용되지 않은 HTTP method입니다."),
+	INVALID_INPUT_VALUE(400, "G003", "유효하지 않은 입력입니다."),
+	INVALID_INPUT_TYPE(400, "G004", "입력 타입이 유효하지 않습니다."),
+	HTTP_MESSAGE_NOT_READABLE(400, "G005", "request message body가 없거나, 값 타입이 올바르지 않습니다."),
+	HTTP_HEADER_INVALID(400, "G006", "request header가 유효하지 않습니다."),
+	ENTITY_TYPE_INVALID(500, "G007", "올바르지 않은 entity type 입니다."),
+    
+    //! JWT
+    JWT_INVALID(40, "J001", "유효하지 않은 토큰입니다."),
+    JWT_EXPIRED(410, "J002", "만료된 토큰입니다."),
+    EXPIRED_REFRESH_TOKEN(401, "J003", "만료된 Refresh 토큰입니다. 재로그인이 필요합니다."),
+
+    ;
+
+    private final int status;
+    private final String code;
+    private final String message;
+
+}

--- a/src/main/java/com/sopt/wokat/global/error/ErrorResponse.java
+++ b/src/main/java/com/sopt/wokat/global/error/ErrorResponse.java
@@ -1,0 +1,105 @@
+package com.sopt.wokat.global.error;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.validation.BindingResult;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import jakarta.validation.ConstraintViolation;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ErrorResponse {
+    
+    private int status;
+    private String code;
+    private String message;
+    private List<FieldError> errors;
+
+    private ErrorResponse(final ErrorCode code, final List<FieldError> errors) {
+        this.status = code.getStatus();
+        this.code = code.getCode();
+        this.message = code.getMessage();
+        this.errors = errors;
+    }
+
+    private ErrorResponse(final ErrorCode code) {
+        this.status = code.getStatus();
+        this.code = code.getCode();
+        this.message = code.getMessage();
+        this.errors = new ArrayList<>();
+    }
+
+    public static ErrorResponse of(final ErrorCode code, final BindingResult bindingResult) {
+        return new ErrorResponse(code, FieldError.of(bindingResult));
+    }
+
+    public static ErrorResponse of(final ErrorCode code, final Set<ConstraintViolation<?>> constraintViolations) {
+        return new ErrorResponse(code, FieldError.of(constraintViolations));
+    }
+
+    public static ErrorResponse of(final ErrorCode code, final String missingParameterName) {
+        return new ErrorResponse(code, FieldError.of(missingParameterName, "", "parameter must required"));
+    }
+
+    public static ErrorResponse of(final ErrorCode code) {
+        return new ErrorResponse(code);
+    }
+
+    public static ErrorResponse of(final ErrorCode code, final List<FieldError> errors) {
+        return new ErrorResponse(code, errors);
+    }
+
+    public static ErrorResponse of(MethodArgumentTypeMismatchException e) {
+        final String value = e.getValue() == null ? "" : e.getValue().toString();
+        final List<FieldError> errors = FieldError.of(e.getName(), value, e.getErrorCode());
+        return new ErrorResponse(ErrorCode.INVALID_INPUT_TYPE, errors);
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class FieldError {
+
+        private String field;
+        private String value;
+        private String reason;
+
+        public static List<FieldError> of(final String field, final String value, final String reason) {
+            List<FieldError> fieldErrors = new ArrayList<>();
+            fieldErrors.add(new FieldError(field, value, reason));
+            return fieldErrors;
+        }
+
+        public static List<FieldError> of(final BindingResult bindingResult) {
+            final List<org.springframework.validation.FieldError> fieldErrors = bindingResult.getFieldErrors();
+            return fieldErrors.stream()
+                    .map(error -> new FieldError(
+                            error.getField(), 
+                            error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(), 
+                            error.getDefaultMessage()
+                    ))
+                    .collect(Collectors.toList());
+        }
+
+        public static List<FieldError> of(final Set<ConstraintViolation<?>> constraintViolations) {
+            List<ConstraintViolation<?>> lists = new ArrayList<>(constraintViolations);
+            return lists.stream()
+                    .map(error -> new FieldError(
+                            error.getPropertyPath().toString(),
+                            "",
+                            error.getMessageTemplate()
+                    ))
+                    .collect(Collectors.toList());
+            }
+        }
+
+}
+

--- a/src/main/java/com/sopt/wokat/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/sopt/wokat/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,105 @@
+package com.sopt.wokat.global.error;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestCookieException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
+
+import com.sopt.wokat.global.error.exception.BusinessException;
+
+import jakarta.validation.ConstraintViolationException;
+
+import static com.sopt.wokat.global.error.ErrorCode.INTERNAL_SERVER_ERROR;
+import static com.sopt.wokat.global.error.ErrorCode.METHOD_NOT_ALLOWED;
+import static com.sopt.wokat.global.error.ErrorCode.*;
+import static org.springframework.http.HttpStatus.*;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler
+	protected ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(
+		MissingServletRequestParameterException e) {
+		final ErrorResponse response = ErrorResponse.of(INVALID_INPUT_VALUE, e.getParameterName());
+		return new ResponseEntity<>(response, BAD_REQUEST);
+	}
+
+	@ExceptionHandler
+	protected ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException e) {
+		final ErrorResponse response = ErrorResponse.of(INVALID_INPUT_VALUE, e.getConstraintViolations());
+		return new ResponseEntity<>(response, BAD_REQUEST);
+	}
+
+	@ExceptionHandler
+	protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+		final ErrorResponse response = ErrorResponse.of(INVALID_INPUT_VALUE, e.getBindingResult());
+		return new ResponseEntity<>(response, BAD_REQUEST);
+	}
+
+	@ExceptionHandler
+	protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
+		final ErrorResponse response = ErrorResponse.of(INVALID_INPUT_VALUE, e.getBindingResult());
+		return new ResponseEntity<>(response, BAD_REQUEST);
+	}
+
+	@ExceptionHandler
+	protected ResponseEntity<ErrorResponse> handleMissingServletRequestPartException(
+		MissingServletRequestPartException e) {
+		final ErrorResponse response = ErrorResponse.of(INVALID_INPUT_VALUE, e.getRequestPartName());
+		return new ResponseEntity<>(response, BAD_REQUEST);
+	}
+
+	@ExceptionHandler
+	protected ResponseEntity<ErrorResponse> handleMissingServletRequestPartException(
+		MissingRequestCookieException e) {
+		final ErrorResponse response = ErrorResponse.of(INVALID_INPUT_VALUE, e.getCookieName());
+		return new ResponseEntity<>(response, BAD_REQUEST);
+	}
+
+	@ExceptionHandler
+	protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
+		MethodArgumentTypeMismatchException e) {
+		final ErrorResponse response = ErrorResponse.of(e);
+		return new ResponseEntity<>(response, BAD_REQUEST);
+	}
+
+	@ExceptionHandler
+	protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+		final ErrorResponse response = ErrorResponse.of(HTTP_MESSAGE_NOT_READABLE);
+		return new ResponseEntity<>(response, BAD_REQUEST);
+	}
+
+	@ExceptionHandler
+	protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(
+		HttpRequestMethodNotSupportedException e) {
+		final List<ErrorResponse.FieldError> errors = new ArrayList<>();
+		errors.add(new ErrorResponse.FieldError("http method", e.getMethod(), METHOD_NOT_ALLOWED.getMessage()));
+		final ErrorResponse response = ErrorResponse.of(HTTP_HEADER_INVALID, errors);
+		return new ResponseEntity<>(response, BAD_REQUEST);
+	}
+
+	@ExceptionHandler
+	protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+		final ErrorCode errorCode = e.getErrorCode();
+		final ErrorResponse response = ErrorResponse.of(errorCode, e.getErrors());
+		return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getStatus()));
+	}
+
+	@ExceptionHandler
+	protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+		final ErrorResponse response = ErrorResponse.of(INTERNAL_SERVER_ERROR);
+		return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+	}
+
+}

--- a/src/main/java/com/sopt/wokat/global/error/exception/BusinessException.java
+++ b/src/main/java/com/sopt/wokat/global/error/exception/BusinessException.java
@@ -1,0 +1,33 @@
+package com.sopt.wokat.global.error.exception;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.sopt.wokat.global.error.ErrorCode;
+import com.sopt.wokat.global.error.ErrorResponse;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    
+    private ErrorCode errorCode;
+    private List<ErrorResponse.FieldError> errors = new ArrayList<>();
+    
+    public BusinessException(String message,ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, List<ErrorResponse.FieldError> errors) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.errors = errors;
+    } 
+    
+
+}

--- a/src/main/java/com/sopt/wokat/global/result/ResultCode.java
+++ b/src/main/java/com/sopt/wokat/global/result/ResultCode.java
@@ -1,0 +1,30 @@
+package com.sopt.wokat.global.result;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * ResultCode Convention
+ * - 도메인 별로 나누어 관리
+ * - [동사_목적어_SUCCESS] 형태로 생성
+ * - 코드는 도메인명 앞에서부터 1~2글자로 사용
+ * - 메시지는 "~~다."로 마무리
+ */
+
+@Getter
+@AllArgsConstructor
+public enum ResultCode {
+    
+    // User
+    REGISTER_SUCCESS(200, "M001", "회원가입 되었습니다."),
+    LOGIN_SUCCESS(200, "M002", "로그인 되었습니다."),
+    REFRESH_SUCCESS(200, "M003", "재발급 되었습니다."),
+    LOGOUT_SUCCESS(200, "M004", "로그아웃 되었습니다."),
+
+    ;
+
+    private final int status;
+    private final String code;
+    private final String message;
+
+}

--- a/src/main/java/com/sopt/wokat/global/result/ResultResponse.java
+++ b/src/main/java/com/sopt/wokat/global/result/ResultResponse.java
@@ -1,0 +1,25 @@
+package com.sopt.wokat.global.result;
+
+public class ResultResponse {
+    
+    private int status;
+    private String code;
+    private String message;
+    private Object data;
+
+    public ResultResponse(ResultCode resultCode, Object data) {
+        this.status = resultCode.getStatus();
+        this.code = resultCode.getCode();
+        this.message = resultCode.getMessage();
+        this.data= data;
+    }
+
+    public static ResultResponse of(ResultCode resultCode, Object data) {
+        return new ResultResponse(resultCode, data);
+    }
+
+    public static ResultResponse of(ResultCode resultCode) {
+		return new ResultResponse(resultCode, "");
+	}
+
+}


### PR DESCRIPTION
## 📌 개요
- Exception 핸들링 설정
- ErrorResponse / ResultResponse 설정

## 📝 작업사항
- 일관된 Error&Response 객체를 반환하기 위해 ErrorResponse, ResultResponse 작성
   `return ResponseEntity.ok(ResultResponse.of(RESULT_EXAMPLE));` 처럼 호출 

- BusinessException을 작성해 Exception 객체들이 상속받아 사용할 수 있도록 로직 구성 
  ```
  public class ExampleException extends BusinessException {
      public ExampleException() {
          super(ErrorCode.EXAMPLE_CODE);
      }
  }
  ```
  위와 같이 사용하며, `.orElseThrow(AuthenticationNotFoundException::new);` 처럼 호출

## 📣 변경로직